### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ See [**Project Structure Guide**](PROJECT_STRUCTURE.md) for detailed folder and 
 ## ⭐ Star History
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Thisal-D/PyTube-Downloader&type=Date&theme=dark">
-  <img src="https://api.star-history.com/svg?repos=Thisal-D/PyTube-Downloader&type=Date&theme=light">
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Thisal-D/PyTube-Downloader&type=Date&theme=dark">
+  <img src="https://star-history.dera.page/svg?repos=Thisal-D/PyTube-Downloader&type=Date&theme=light">
 </picture>
 
 ---

--- a/README_zh.md
+++ b/README_zh.md
@@ -131,8 +131,8 @@ python main.py
 ## ⭐ Star 增长历史
 
 <picture> 
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Thisal-D/PyTube-Downloader&type=Date&theme=dark">
-  <img src="https://api.star-history.com/svg?repos=Thisal-D/PyTube-Downloader&type=Date&theme=light">
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Thisal-D/PyTube-Downloader&type=Date&theme=dark">
+  <img src="https://star-history.dera.page/svg?repos=Thisal-D/PyTube-Downloader&type=Date&theme=light">
 </picture>
 
 ---


### PR DESCRIPTION
The star history chart on the README is currently broken. The GitHub stargazer API that powers star-history.com is now heavily rate-limited, which makes the chart fail to render on both the English and Chinese readmes.

This PR switches the chart to a mirror that works around those rate limits and requires no API token, so the chart displays correctly again. No other part of the README is changed.